### PR TITLE
Rewrite to use MongoDB library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "marc-mabe/zend-cache": "^3.0",
-        "ext-mongo": ">=1.3.0"
+        "mongodb/mongodb": ">=1.1.0"
     },
     "require-dev": {
         "marc-mabe/zend-cache-test": "^3.0",

--- a/test/MongoResourceManagerTest.php
+++ b/test/MongoResourceManagerTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\Mongo;
 
-use MongoClient;
+use MongoDB\Client as MongoClient;
+use MongoDB\Collection as MongoCollection;
 use PHPUnit\Framework\TestCase;
 use Zend\Cache\Exception;
 use Zend\Cache\Mongo\MongoResourceManager;
@@ -119,7 +120,7 @@ class MongoResourceManagerTest extends TestCase
         $this->object->setDatabase($id, $database);
         $this->object->setCollection($id, $collection);
 
-        $this->assertInstanceOf('\MongoCollection', $this->object->getResource($id));
+        $this->assertInstanceOf(MongoCollection::class, $this->object->getResource($id));
     }
 
     public function testGetResourceUnknownServerThrowsException()
@@ -135,7 +136,7 @@ class MongoResourceManagerTest extends TestCase
         $this->object->setDatabase($id, $database);
         $this->object->setCollection($id, $collection);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(\MongoDB\Driver\Exception\RuntimeException::class);
         $this->object->getResource($id);
     }
 


### PR DESCRIPTION
TO-DO: now is disabled to support of storing arrays (MongoAdapter:227). The solution is to add serializer plugin in cache configuration in your app [https://docs.zendframework.com/zend-cache/storage/plugin/].

unit test: OK
cs-check: OK